### PR TITLE
Updates for the Mental Health (Discrimination) Act 2013

### DIFF
--- a/hacklab_articles.tex
+++ b/hacklab_articles.tex
@@ -539,10 +539,6 @@ out their duties as a director - but only if that has
 continued (or is expected to continue) for a period of more than six
 months;}
 
-\subclause{by reason of that person's mental health, a court makes an order
-which wholly or partly prevents them from personally exercising any powers
-or rights which they would otherwise have;}
-
 \subclause{they cease to be a member of the Hacklab;}
 
 \subclause{they give the Hacklab a notice of resignation, signed by


### PR DESCRIPTION
"Amendments to model articles

The model articles were amended by the Mental Health (Discrimination) Act 2013 on 28 April 2013 to remove the provision for terminating a director’s appointment on grounds of mental health. This provision could be found in:

    paragraph 18(e) of the model articles for private companies limited by shares or by guarantee
    paragraph 22(e) of the model articles for public companies

You don’t have to remove the provision if it’s in your articles, but you can do so by amending your articles or by adopting the newer model articles."

In section 3, Company directors, omit Schedule 2, paragraph 18(e).