### PR TITLE
Updates based on companies act and model articles

### DIFF
--- a/hacklab_articles.tex
+++ b/hacklab_articles.tex
@@ -792,7 +792,7 @@ any remuneration by the Hacklab for carrying out their duties as a director.}
   director, but other members of a sub-committee need not be
   directors.}
 
-\clause{When delegating powers under clause \ref{clause:delegation}:
+\clause{When delegating powers under clause \ref{clause:delegation}:}
   
  \subclause{committees must follow procedures which are based as far as they are applicable on those provisions of the articles which govern the taking of decisions by directors;}
  

--- a/hacklab_articles.tex
+++ b/hacklab_articles.tex
@@ -63,16 +63,18 @@ hereafter referred to as ``the Hacklab''.}
 
 \clause{In the articles:}
   \begin{description}
-  \item[Address] means a postal address or, for the purposes of
-    electronic communication, an e-mail address in each case
-    registered with the Hacklab
-  \item[Articles] means these articles of association
+  \item[Address] means a postal address or, for the purposes of electronic communication, an e-mail address in each case registered with the Hacklab;
+  \item[Articles] means these articles of association;
+  \item[Bankruptcy] includes individual insolvency proceedings in a jurisdiction other than England and Wales or Northern Ireland which have an effect similar to that of bankruptcy;
   \item[Companies Acts] means the Companies Acts (as defined in section 2 of the Companies Act 2006), in so far as they apply to the company;
   \item[Director] means a director of the company, and includes any person occupying the position of director, by whatever name called;
   \item[Document] includes, unless otherwise specified, any document sent or supplied in electronic form;
   \item[Electronic Form] has the meaning given in section 1168 of the Companies Act 2006;
   \item[Member] has the meaning given in section 112 of the Companies Act 2006;
+  %\item[Ordinary resolution] has the meaning given in section 282 of the Companies Act 2006;
   \item[Proxy Notice] has the meaning given in article \ref{clause:proxy};
+  %\item[Special resolution] has the meaning given in section 283 of the Companies Act 2006;
+  \item[Writing] means the representation or reproduction of words, symbols or other information in a visible form by any method or combination of methods, whether sent or supplied in electronic form or otherwise.
   \end{description}
 Unless the context otherwise requires, other words or expressions contained in these articles bear the same meaning as in the Companies Act 2006 as in force on the date when these articles become binding on the company.
 
@@ -387,7 +389,7 @@ vote - with the exception of the types of resolution listed in clause
 
 \clause{\label{clause:supermajority}The following resolutions will be valid only if passed by not
 less that two-thirds of those voting on the resolution at an AGM or
-EGM (or if passed by way of a written resolution under clause
+EGM (or if passed by way of a written resolution by not less than two thirds of eligible members under clause
 \ref{clause:writtenresolution}):}
 
 \subclause{a resolution amending the articles;}
@@ -461,9 +463,11 @@ executed it to execute it on the appointor's behalf.}
 \subsection{Written resolutions by members}
 
 \clause{\label{clause:writtenresolution}A resolution agreed to in
-  writing (or by e-mail) by all the members will be as valid as if it
+  writing (or by e-mail) will be as valid as if it
   had been passed at a general meeting; the date of the resolution
   will be taken to be the date on which the last member agreed to it.}
+  \subclause{A written resolution is passed by a majority of not less than 50% if it is passed by members representing not less than 50% of the total voting rights of eligible members,}
+  \subclause{with the exception of the types of resolution listed in clause \ref{clause:supermajority} which will be passed by a majority of not less than two thirds if it is passed by members representing not less than two thirds of the total voting rights of eligible members.}
 
 \subsection{Minutes}
 
@@ -788,9 +792,12 @@ any remuneration by the Hacklab for carrying out their duties as a director.}
   director, but other members of a sub-committee need not be
   directors.}
 
-\clause{When delegating powers under clause \ref{clause:delegation},
-  the board must set out appropriate conditions (which must include an
-  obligation to report regularly to the board).}
+\clause{When delegating powers under clause \ref{clause:delegation}:
+  
+ \subclause{committees must follow procedures which are based as far as they are applicable on those provisions of the articles which govern the taking of decisions by directors;}
+ 
+ \subclause{the board may set out appropriate conditions or procedures for the committee which prevail over rules defined by the articles if they are not consistent with them;}
+ \subclause{all committees are obliged to report regularly to the board.}
 
 \clause{Any delegation of powers under clause \ref{clause:delegation}
   may be revoked or altered by the board at any time.}
@@ -825,6 +832,23 @@ account must be consistent with the approach reflected in clause
   relevant statutory requirements.}
 
 %\clause{The financial year shall run from 1st April to 31st March.}
+
+\subsection{Directors' Indemnity and Insurance}
+
+\subsection{Indemnity}
+\clause{A relevant director of the company or an associated company may be indemnified out of the company’s assets against—
+(a) any liability incurred by that director in connection with any negligence, default, breach of duty or breach of trust in relation to the company or an associated company,
+(b) any other liability incurred by that director as an officer of the company.}
+\subclause{This article does not authorise any indemnity which would be prohibited or rendered void by any provision of the Companies Acts or by any other provision of law.}
+\subclause{In this article a “relevant director” means any director or former director of the company}
+
+
+\subsection{Insurance}
+
+\clause{The directors may decide to purchase and maintain insurance, at the expense of the company, for the benefit of any relevant director in respect of any relevant loss. In this article}
+\subclause{(a) a “relevant director” means any director or former director of the company or an associated company,}
+\subclause{(b) a “relevant loss” means any loss or liability which has been or may be incurred by a relevant director in connection with that director’s duties or powers in relation to the company}
+
 
 \section{Miscellaneous}
 

--- a/hacklab_articles.tex
+++ b/hacklab_articles.tex
@@ -466,8 +466,8 @@ executed it to execute it on the appointor's behalf.}
   writing (or by e-mail) will be as valid as if it
   had been passed at a general meeting; the date of the resolution
   will be taken to be the date on which the last member agreed to it.}
-  \subclause{A written resolution is passed by a majority of not less than 50% if it is passed by members representing not less than 50% of the total voting rights of eligible members,}
-  \subclause{with the exception of the types of resolution listed in clause \ref{clause:supermajority} which will be passed by a majority of not less than two thirds if it is passed by members representing not less than two thirds of the total voting rights of eligible members.}
+  \subclause{A written resolution is passed by a majority if it is passed by members representing not less than half of the total voting rights of eligible members,}
+  \subclause{with the exception of the types of resolution listed in clause \ref{clause:supermajority} which will be passed by members representing not less than two thirds of the total voting rights of eligible members.}
 
 \subsection{Minutes}
 


### PR DESCRIPTION
Proposal for update at the 2022 AGM
- Include a provision to ensure written resolutions may be passed with the same thresholds levels as a vote at the AGM/EGM but applied to the total voting rights of all members (which was previously set to all members agreeing with a written resolution - something that would never be achievable)
- Updates to ensure our indemnity insurance for directors is valid as per model articles
- Adds definitions used in model articles, where not previously defined here
- Includes the need for delegated subcommittees to comply with the articles