### PR TITLE
Remove treasurer ambiguity

### DIFF
--- a/hacklab_articles.tex
+++ b/hacklab_articles.tex
@@ -513,8 +513,7 @@ they are disqualified from being a director under the
 
 \clause{\label{clause:boardelection}At each AGM, the members may elect
 any member (unless they are debarred from membership under clause
-\ref{clause:disqualified}) to be the treasurer or one of the other four
-directors.}
+\ref{clause:disqualified}) to be a director.}
 
 \clause{At each AGM, all of the directors must retire from
 office - but shall then (subject to clause \ref{clause:maxperiod}) be


### PR DESCRIPTION
Generally, we haven't specifically elected a treasurer. It's been decided among the directors and membership. Removing the separate election principle gives us the option to have a vote or for one of the directors to volunteer.