### PR TITLE
Board Candidacy Option B

### DIFF
--- a/hacklab_articles.tex
+++ b/hacklab_articles.tex
@@ -333,8 +333,7 @@ as each other.}
 \clause{\label{clause:meeting_notice}At least 14 clear days notice must
 be given of any AGM or any EGM.}
 
-\clause{The reference to ``clear days'' in clause
-\ref{clause:meeting_notice} shall be taken to mean that, in
+\clause{\label{clause:cleardays}References to ``clear days'' shall be taken to mean that, in
 calculating the days of notice,}
 
 \subclause{the day after the notices are posted (or sent by e-mail)
@@ -501,6 +500,8 @@ from that office, signed by them.}
 they are disqualified from being a director under the
 \companyact.}
 
+\clause{A person will not be eligible for election to the board unless they have given notice of their intention to stand for election at least 10 clear days, and not more than 45 clear days, in advance of the election. Clear days are as defined in \ref{clause:cleardays}}
+
 %\subsection{Initial charity trustees}
 
 %\clause{The individuals who signed the charity trustee declaration
@@ -512,8 +513,7 @@ they are disqualified from being a director under the
 \subsection{Election, retiral, re-election}
 
 \clause{\label{clause:boardelection}At each AGM, the members may elect
-any member (unless they are debarred from membership under clause
-\ref{clause:disqualified}) to be the treasurer or one of the other four
+any eligible member to be the treasurer or one of the other four
 directors.}
 
 \clause{At each AGM, all of the directors must retire from
@@ -543,14 +543,6 @@ be a period of one year;}
 reelected to that office within a period of six months, they shall
 be deemed to have held office as a director continuously.}
 
-\clause{\label{clause:directorelection}A director retiring at
-  an AGM will be deemed to have been re-elected unless:}
-
-\subclause{they advise the board prior to the conclusion of the AGM
-that they do not wish to be reappointed as a director; or}
-
-\subclause{an election process was held at the AGM and they were not
-among those elected/re-elected through that process.}
 
 \subsection{Termination of office}
 
@@ -587,7 +579,7 @@ but only if the board resolves to remove them from office.}
 \subclause{\label{clause:removedbymembers}they are removed from
   office by a resolution of the members passed at a general meeting.}
 
-\clause{A resolution under paragraph \ref{clause:materialbreach},
+\clause{label{clause:directorelection}A resolution under paragraph \ref{clause:materialbreach},
 or \ref{clause:removedbymembers} shall
 be valid only if:}
 

--- a/hacklab_articles.tex
+++ b/hacklab_articles.tex
@@ -579,7 +579,7 @@ but only if the board resolves to remove them from office.}
 \subclause{\label{clause:removedbymembers}they are removed from
   office by a resolution of the members passed at a general meeting.}
 
-\clause{label{clause:directorelection}A resolution under paragraph \ref{clause:materialbreach},
+\clause{A resolution under paragraph \ref{clause:materialbreach},
 or \ref{clause:removedbymembers} shall
 be valid only if:}
 
@@ -595,6 +595,15 @@ resolution being put to the vote; and}
 \ref{clause:materialbreach} at least
 two thirds (to the nearest round number) of the directors then
 in office vote in favour of the resolution.}
+
+\clause{\label{clause:directorelection}A director retiring at
+  an AGM will be deemed to have been re-elected unless:}
+
+\subclause{they advise the board prior to the conclusion of the AGM
+that they do not wish to be reappointed as a director; or}
+
+\subclause{an election process was held at the AGM and they were not
+among those elected/re-elected through that process.}
 
 \subsection{Register of directors}
 


### PR DESCRIPTION
As per River's proposal this version requires notification of intent to stand. However, in the event that there is not an election, clause 70 remains. This is important as all directors must stand down at an AGM and be reelected so if nobody came forward specifically within the proscribed period we could end up with no directors.

Clause 70 is 

"A director retiring at an AGM will be deemed to have been re-elected unless:
70.1 they advise the board prior to the conclusion of the AGM that they do not wish to be reappointed as a director; or
70.2 an election process was held at the AGM and they were not among those elected/re-elected through that process."