### PR TITLE
changes to written resolutions, from https://github.com/edinburghhack…

### DIFF
--- a/hacklab_articles.tex
+++ b/hacklab_articles.tex
@@ -387,7 +387,7 @@ vote - with the exception of the types of resolution listed in clause
 
 \clause{\label{clause:supermajority}The following resolutions will be valid only if passed by not
 less that two-thirds of those voting on the resolution at an AGM or
-EGM (or if passed by way of a written resolution under clause
+EGM (or if passed by way of a written resolution by not less than two thirds of eligible members under clause
 \ref{clause:writtenresolution}):}
 
 \subclause{a resolution amending the articles;}
@@ -461,9 +461,11 @@ executed it to execute it on the appointor's behalf.}
 \subsection{Written resolutions by members}
 
 \clause{\label{clause:writtenresolution}A resolution agreed to in
-  writing (or by e-mail) by all the members will be as valid as if it
+  writing (or by e-mail) will be as valid as if it
   had been passed at a general meeting; the date of the resolution
   will be taken to be the date on which the last member agreed to it.}
+  \subclause{A written resolution is passed by a majority if it is passed by members representing not less than half of the total voting rights of eligible members,}
+  \subclause{with the exception of the types of resolution listed in clause \ref{clause:supermajority} which will be passed by members representing not less than two thirds of the total voting rights of eligible members.}
 
 \subsection{Minutes}
 


### PR DESCRIPTION
Changes extracted from https://github.com/edinburghhacklab/company/pull/7

>  * Include a provision to ensure written resolutions may be passed with the same thresholds levels as a vote at the AGM/EGM but applied to the total voting rights of all members (which was previously set to all members agreeing with a written resolution - something that would never be achievable)

We are splitting https://github.com/edinburghhacklab/company/pull/7 into two parts, one about written resolutions (this one), the other about the "clean up", in order to resolve a conflict with https://github.com/edinburghhacklab/company/pull/12.